### PR TITLE
Replacing API deprecated with Sketch 53. Fixes #53

### DIFF
--- a/Sketch-Isometric.sketchplugin/Contents/Sketch/scripts/common.js
+++ b/Sketch-Isometric.sketchplugin/Contents/Sketch/scripts/common.js
@@ -567,7 +567,11 @@ MD.extend({
     }   
 
     this.document.currentPage().addLayers([groupLayer]);
-    groupLayer.resizeToFitChildrenWithOption(0);
+    if (MSApplicationMetadata.metadata().appVersion >= 53) {
+      groupLayer.fixGeometryWithOptions(1);
+    } else {
+      groupLayer.resizeToFitChildrenWithOption(0);
+    }
 
     var Group_W = groupLayer.frame().width();
     MD.superDebug("Group_W", Group_W);


### PR DESCRIPTION
Replacing resizeToFitChildrenWithOption(0) with fixGeometryWithOptions(1) to work with Sketch 53.
Preserving backwards compatibility with Sketch 52 by checking MSApplicationMetadata.metadata().appVersion.